### PR TITLE
feat(resets): fixed

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -246,6 +246,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
 document.getElementById('reset-button').addEventListener('click', function() {
   internsMap.clear();
+  selectedInterns = [];
+  checkedInterns = [];
   
   const tbody = document.querySelector("#interns-display tbody");
   tbody.innerHTML = "";
@@ -261,6 +263,8 @@ document.getElementById('reset-button').addEventListener('click', function() {
 });
 
 document.querySelector('.reset-all-buttons').addEventListener('click', function() {
+  selectedInterns = [];
+  checkedInterns = [];
   
   let locationButtons = document.querySelectorAll('.location-button');
   locationButtons.forEach(button => {

--- a/src/script.js
+++ b/src/script.js
@@ -263,6 +263,7 @@ document.getElementById('reset-button').addEventListener('click', function() {
 });
 
 document.querySelector('.reset-all-buttons').addEventListener('click', function() {
+  internsMap.clear();
   selectedInterns = [];
   checkedInterns = [];
   


### PR DESCRIPTION
## Changes

_List Changes Introduced by this PR_

1. Added references to selectedInterns AND checkedInterns to both reset button fuctions in script.js
2. selectedInterns AND checkedInterns both set to [ ]

## Purpose

Making sure that the table isn't only being reset visually, but that the ACTUAL lists we have are reset too.

## Approach

By setting the two lists of interns to an empty array, we essentially reset.

## Pre-Testing TODOs

Select some interns.

## Testing Steps

Remove them, then reset the table. Then generate a new table. 
The previously removed interns should now appear in the new table.

Closes #77
